### PR TITLE
Improved Color handling.

### DIFF
--- a/weechat.el
+++ b/weechat.el
@@ -70,7 +70,7 @@ See `format-time-string' for format description."
   :type 'string
   :group 'weechat)
 
-(defface weechat-prompt-face '((t :weight bold :foreground "black" :background "grey90"))
+(defface weechat-prompt-face '((t :inherit minibuffer-prompt))
   "Weechat face used for the prompt."
   :group 'weechat)
 


### PR DESCRIPTION
The Weechat color codes are a pretty shitty format and parsing them is
quite a pain...

http://www.weechat.org/files/doc/devel/weechat_dev.en.html#color_codes_in_strings
Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de

Conflicts:
    weechat.el
