### PR TITLE
complete on /query as well as /QUERY

### DIFF
--- a/weechat-complete.el
+++ b/weechat-complete.el
@@ -112,6 +112,7 @@ Copied from `pcomplete-erc-command-name'."
   (pcomplete-here
    (append
     (pcomplete-weechat-commands)
+    (mapcar 'downcase (pcomplete-weechat-commands))
     (pcomplete-weechat-nicks weechat-complete-nick-postfix weechat-complete-nick-ignore-self))))
 
 (defun pcomplete/weechat-mode/WHOIS ()


### PR DESCRIPTION
alternatively, could snatch the function used in ERC:


    (defun pcomplete-erc-commands ()
      "Returns a list of strings of the defined user commands."
      (let ((case-fold-search nil))
        (mapcar (lambda (x)
                  (concat "/" (downcase (substring (symbol-name x) 8))))
                (apropos-internal "erc-cmd-[A-Z]+"))))

