### PR TITLE
Fix the argument order to auth-source-search

### DIFF
--- a/weechat.el
+++ b/weechat.el
@@ -549,9 +549,9 @@ Returns either a string or a function.  See Info node `(auth) Top' for details."
     (weechat-message "Using auth-source to retrieve weechat relay password")
     (plist-get
      (car (auth-source-search
-           :max 1
            :host host
            :port port
+           :max 1
            :require '(:secret)))
      :secret)))
 


### PR DESCRIPTION
For some reason, auth-source-search doesn't return any results, unless
you use :max after :host and :port