### PR TITLE
Add nick completion prefix

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,5 +1,17 @@
 # -*- mode:org; mode:auto-fill; fill-column:80; coding:utf-8; -*-
 * 0.3 (In Progress)
+** New Features
+*** Nick prefix support  =weechat-complete-nick-prefix=
+    If you need to add "@" before nicks, so that they see the mention you can
+    do it for certain channels with:
+
+    #+begin_src emacs-lisp
+    (add-hook 'weechat-mode-hook
+              (lambda ()
+                (when (equal (buffer-name) "gitter.#syl20bnr/spacemacs")
+                  (setq-local weechat-complete-nick-prefix "@"))))
+    #+end_src
+
 ** New Modules
 *** Commands: =weechat-cmd=
     Implement IRC commands (/command) in elisp

--- a/weechat-complete.el
+++ b/weechat-complete.el
@@ -39,6 +39,14 @@
 (defvar weechat-user-list)
 (defvar weechat-prompt-end-marker)
 
+(defcustom weechat-complete-nick-prefix ""
+  "Prefix to nick completions at the beginning of the prompt.
+One common case is that a messaging service provides an IRC
+server (e.g. Flowdock and Gitter), but the mentions have to be
+prefixed with '@' to be highlighted in the other clients."
+  :type 'string
+  :group 'weechat)
+
 (defcustom weechat-complete-nick-postfix ":"
   "Postfix to nick completions at the beginning of the prompt."
   :type 'string
@@ -112,7 +120,7 @@ Copied from `pcomplete-erc-command-name'."
   (pcomplete-here
    (append
     (pcomplete-weechat-commands)
-    (pcomplete-weechat-nicks weechat-complete-nick-postfix weechat-complete-nick-ignore-self))))
+    (pcomplete-weechat-nicks weechat-complete-nick-prefix weechat-complete-nick-postfix weechat-complete-nick-ignore-self))))
 
 (defun pcomplete/weechat-mode/WHOIS ()
   (pcomplete-here (pcomplete-weechat-all-nicks)))
@@ -127,16 +135,19 @@ Copied from `pcomplete-erc-command-name'."
   "Return a list of user commands."
   '("/NICK" "/JOIN" "/PART" "/WHOIS" "/QUERY")) ;; TODO
 
-(defun pcomplete-weechat-nicks (&optional postfix ignore-self)
+(defun pcomplete-weechat-nicks (&optional prefix postfix ignore-self)
   "Return a list of nicks in the current channel.
+PREFIX is an optional string to prefix to the nickname.
 POSTFIX is an optional string to append to the nickname.
 If IGNORE-SELF is non-nil the users nick is ignored."
   (let ((users weechat-user-list))
     (when ignore-self
       (setq users (delete (weechat-get-local-var "nick") users)))
-    (if (stringp postfix)
-        (mapcar (lambda (nick) (concat nick postfix)) users)
-      users)))
+    (mapcar (lambda (nick) (concat
+                            (when (stringp prefix) prefix)
+                            nick
+                            (when (stringp postfix) postfix)))
+            users)))
 
 (defun pcomplete-weechat-all-nicks ()
   "Return nick list of all weechat buffers."


### PR DESCRIPTION
One common case is that a messaging service provides an IRC server (e.g. Flowdock [1] and Gitter [2]), but the mentions have to be prefixed with '@' to be highlighted in the other clients.

Is this the best way to set buffer-local variables to certain channels?

```
(add-hook 'weechat-mode-hook
            (lambda ()
            (when (equal (buffer-name) "gitter.#syl20bnr/spacemacs")
                (setq-local weechat-complete-nick-prefix "@"))))
```

[1] https://irc.gitter.im/
[2] https://www.flowdock.com/help/irc