### PR TITLE
Add nick completion prefix functionality (alist version)

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,8 @@
 ** New Modules
 *** Commands: =weechat-cmd=
     Implement IRC commands (/command) in elisp
+** New Features
+*** Nick prefix support  =weechat-complete-nick-prefix-alist=
 
 * 0.2
 ** Incompatible Changes

--- a/weechat-complete.el
+++ b/weechat-complete.el
@@ -39,6 +39,17 @@
 (defvar weechat-user-list)
 (defvar weechat-prompt-end-marker)
 
+(defcustom weechat-complete-nick-prefix-alist nil
+  "Alist of nick prefixes to use for certain buffers
+Each element looks like (BUFFER-NAME-REGEXP . NICK-PREFIX). If
+BUFFER-NAME-REGEXP matches the current buffer, then NICK-PREFIX
+is appended to each nick in `weechat-user-list'. One common use
+case is that a messaging service provides an IRC server (e.g.
+Flowdock and Gitter), but the mentions have to be prefixed with
+'@' to be highlighted in the other clients."
+  :type '(alist :key-type regexp :value-type string)
+  :group 'weechat)
+
 (defcustom weechat-complete-nick-postfix ":"
   "Postfix to nick completions at the beginning of the prompt."
   :type 'string
@@ -131,12 +142,26 @@ Copied from `pcomplete-erc-command-name'."
   "Return a list of nicks in the current channel.
 POSTFIX is an optional string to append to the nickname.
 If IGNORE-SELF is non-nil the users nick is ignored."
-  (let ((users weechat-user-list))
+  (let ((users weechat-user-list)
+        (prefix (weechat-complete-nick-prefix-for-current-buffer)))
     (when ignore-self
       (setq users (delete (weechat-get-local-var "nick") users)))
-    (if (stringp postfix)
-        (mapcar (lambda (nick) (concat nick postfix)) users)
-      users)))
+    (mapcar (lambda (nick)
+              (concat
+               prefix
+               nick
+               postfix)) users)))
+
+(defun weechat-complete-nick-prefix-for-current-buffer ()
+  "Returns the nick-prefix for the current buffer."
+  (let ((found-nick-prefix nil))
+    (mapc (lambda (element)
+            (let ((buffer-name-regexp (car element))
+                  (nick-prefix (cdr element)))
+              (when (string-match buffer-name-regexp (buffer-name))
+                (setq found-nick-prefix nick-prefix))))
+          weechat-complete-nick-prefix-alist)
+    found-nick-prefix))
 
 (defun pcomplete-weechat-all-nicks ()
   "Return nick list of all weechat buffers."


### PR DESCRIPTION
One common case is that a messaging service provides an IRC server (e.g. Flowdock and Gitter), but the mentions have to be prefixed with '@' to be highlighted in the other clients.

This is an alternative to PR #42. The nick prefix functionality is only meant for specific buffers, so it makes it natural to be able to attach prefixes only to certain buffers with regexp matching.
