### PR TITLE
weechat-get-more-lines

### DIFF
--- a/weechat.el
+++ b/weechat.el
@@ -1500,6 +1500,7 @@ If prefix argument is given (\\[universal-argument]) the prompt is not skipped."
      :active (< (point) weechat-prompt-start-marker)]
     "-"
     ["Reload Buffer" weechat-reload-buffer t]
+    ["Get More Lines" weechat-get-more-lines t]
     ["Close Buffer" kill-buffer t]
     ["Switch Buffer" weechat-switch-buffer t]
     ["Monitor Buffer" weechat-monitor-buffer t]

--- a/weechat.el
+++ b/weechat.el
@@ -1475,6 +1475,7 @@ If prefix argument is given (\\[universal-argument]) the prompt is not skipped."
     (define-key map (kbd "M-p") 'weechat-previous-input)
     (define-key map (kbd "M-n") 'weechat-next-input)
     (define-key map (kbd "C-c C-r") 'weechat-reload-buffer)
+    (define-key map (kbd "C-c C-g") 'weechat-get-more-lines)
     (define-key map (kbd "TAB") 'completion-at-point)
     (define-key map (kbd "C-a") 'weechat-bol)
     (define-key map (kbd "C-c n l") 'weechat-narrow-to-line)


### PR DESCRIPTION
Here's a possible implementation for `weechat-get-more-lines`, a feature that will allow a user to retrieve lines beyond what `weechat-initial-lines` brought in. For example, if `weechat-initial-lines` was set to 100, I monitor the buffer, then decide I want to see messages before those 100, I can execute `weechat-get-more-lines` to bring in `weechat-more-lines-amount` (default 15). The logic is pretty simple and I use the logic in `weechat-reload-buffer` to achieve this.

To make the behavior intuitive to the user, I had to make a change to `weechat-buffer-line-limit`. `weechat-buffer-line-limit` is now buffer local. If the user had a buffer limit of 1000 with 995 lines of messages and they execute `weechat-get-more-lines` to bring in 15 more lines, they will expect to see 15 more lines (if available), not 5 (because the buffer was truncated). To handle this, the buffer's local `weechat-buffer-line-limit` will increase to handle the possibility of 15 more messages coming in. In this example, we can expect up to 995 + 15 = 1010 messages, so we increase that buffer's `weechat-buffer-line-limit` to 1011 (1010 possible chat messages and one line for the input).

If the user executes `weechat-reload-buffer`, the limit is restored for that buffer and everything goes back to normal.

The user can also specify how many more lines they'd like at runtime via `(weechat-get-more-lines nil 50)`.

One potential nit-pick. Let's say the buffer's `weechat-buffer-line-limit` is 1000 and the user is already displaying 995 messages. If they execute `weechat-get-more-lines` but there are only 10 additional lines available by weechat, then those 10 lines will be retrieved but the `weechat-buffer-line-limit` will be set to (995 + 15 + 1) = 1011 (as in the example above). One could argue that it should have been set to (995 + 10 + 1) = 1006. This could probably be fixed by somehow signaling to `weechat-truncate-buffer` how many lines the user requested, but I didn't want to add too much complexity to your code.

I've played around with this for a bit and it seems to work perfectly.

I'm fairly new to elisp (and emacs in general). If you do decide to pull this in please let me know if there are syntax or design changes you'd like me to make and I'll be happy to rebase.