### PR TITLE
Don't store numbers in secrets.el attributes

### DIFF
--- a/weechat-secrets.el
+++ b/weechat-secrets.el
@@ -68,7 +68,7 @@ A collection named after `weechat-secrets-collection' is created if required."
     (setq password (read-passwd "Password: " 'confirm)))
   (secrets-create-item weechat-secrets-collection
                        (weechat-secrets--to-item host port) password
-                       :host host :port port)
+                       :host host :port (number-to-string port))
   (clear-string password))
 
 (defun weechat-secrets-delete (host port &optional allow-empty-collection)


### PR DESCRIPTION
It seems that the type of the attributes in  `secrets-create-item` must be strings. It is not apparent in [the documentation](https://www.gnu.org/software/emacs/manual/html_node/auth/Secret-Service-API.html). However, I was getting a `wrong type argument: stringp` error when using `weechat-secrets` (GNU Emacs 24.4.1).

This fixes the issue but since the attributes are apparently never retrieved, simply removing them may be considered a better option.