### PR TITLE
Send notifications via libnotify(notify-osd) on systems that support it.

### DIFF
--- a/README.org
+++ b/README.org
@@ -117,6 +117,10 @@
      You can customize =weechat-notifications-sound= to play a sound on
      notification.  Setting =weechat-notifications-icon= allows to change the
      notification icon.
+
+	=weechat-notifications= can also send notifications using [[https://wiki.ubuntu.com/NotifyOSD][notify-osd]]. To
+	enable sending notifications via notify-osd instead of dbus, set
+	=weechat-notifications-handler= to "libnotify".
 **** Sauron
      The =weechat-sauron= module uses [[http://www.emacswiki.org/emacs/Sauron][Sauron]] for notifications.
 *** Tracking

--- a/weechat-notifications.el
+++ b/weechat-notifications.el
@@ -61,6 +61,37 @@ Either nil, a file-name, or a function which is called with (SENDER BUFFER-PTR).
   (when (boundp 'notifications-application-icon)
     notifications-application-icon))
 
+(defcustom weechat-notification-libnotify-timeout 5000
+  "Timeout for the libnotify notification (millseconds)"
+  :group 'weechat-notifications)
+
+(defcustom weechat-notification-default-handler #'weechat-notifications-dbus-handler
+  "The default notifications handler to be used as a hook to
+weechat-notification-handler-functions. The two possible values are:
+- #'weechat-nofifications-dbus-handler
+- #'weechat-notifications-libnotify-handler"
+  :type '(choice (const :tag "dbus" #'weechat-notifications-dbus-handler)
+				 (const :tag "libnotify" #'weechat-notifications-libnotify-handler)
+				 (function :tag "Function"))
+  :group 'weechat-notifications)
+
+(defcustom weechat-notification-libnotify-urgency "low"
+  "Urgency for the notification send via libnotify
+Values can be:
+- low
+- normal
+- critical"
+  :group 'weechat-notifications)
+
+(defun notify-via-libnotify (title &optional body)
+  "Send desktop notifications using libnotify."
+  (call-process "notify-send" nil 0 nil
+                title (if (eq body nil) "" body)
+                "-t" (number-to-string weechat-notification-libnotify-timeout)
+                "-i" "emacs"
+                "-u" weechat-notification-libnotify-urgency
+                "-c" "emacs.message"))
+
 (defvar weechat--notifications-id-to-msg nil
   "Map notification ids to buffer-ptrs.")
 
@@ -75,22 +106,20 @@ Supported actions:
       (when buffer-ptr
         (weechat-switch-buffer buffer-ptr)))))
 
-(defun weechat-notifications-handler (type &optional sender text _date buffer-ptr)
+(defun weechat-notifications-get-title (type &optional sender)
+  (cl-case type
+    (:highlight
+     (concat "Weechat.el: Message from <" sender ">"))
+    (:query
+     (concat "Weechat.el: Query from <" sender ">"))
+    (:disconnect "Disconnected from WeeChat")
+    (t " Weechat.el Alert")))
+
+(defun weechat-notifications-dbus-handler (type &optional sender text _date buffer-ptr)
   "Notification handler using notifications.el."
   (let ((notifications-id
          (notifications-notify
-          :title (xml-escape-string
-                  (or (cl-case type
-                        (:highlight
-                         (concat "Weechat.el: Message from <"
-                                 (weechat-strip-formatting sender)
-                                 ">"))
-                        (:query
-                         (concat "Weechat.el: Query from <"
-                                 (weechat-strip-formatting sender)
-                                 ">"))
-                        (:disconnect "Disconnected from WeeChat"))
-                      ""))
+          :title (weechat-notifications-get-title type (weechat-strip-formatting sender))
           :body (when text (xml-escape-string text))
           :category "im.received"
           :actions '("view" "View")
@@ -111,8 +140,14 @@ Supported actions:
             (append (list (cons notifications-id buffer-ptr))
                     weechat--notifications-id-to-msg)))))
 
+(defun weechat-notifications-libnotify-handler (type &optional sender text _date buffer-ptr)
+  "Notification handler using libnotify."
+  (notify-via-libnotify
+   (weechat-notifications-get-title type sender)
+   (if (eq text nil) nil (xml-escape-string text))))
+
 (add-hook 'weechat-notification-handler-functions
-          #'weechat-notifications-handler)
+          weechat-notification-default-handler)
 
 (provide 'weechat-notifications)
 


### PR DESCRIPTION
Most of the functionality works except for the part where one can choose the notification-handler.

I have defined a custom variable to point to the handler, but it looks like if you set the value of the variable later, it's previous value has already been added to the `weechat-notification-handler-functions` list. 

I am very new to writing elisp, I think I need some help here.