### PR TITLE
In batch, do not put .el for loaded files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ all: package
 	$(info $(NAME) Version: $(VERSION))
 
 test: $(TESTS)
-	@$(BATCH) -l ert.el $(foreach file,$^,-l $(file)) -f ert-run-tests-batch-and-exit
+	@$(BATCH) -l ert $(foreach file,$^,-l $(file)) -f ert-run-tests-batch-and-exit
 
 clean:
 	$(info Cleaning up)
@@ -47,7 +47,7 @@ distclean: clean
 
 README.html: README.org
 	$(info Creating documentation: $@)
-	@$(BATCH) -l org.el --visit=$< -f org-html-export-to-html
+	@$(BATCH) -l org --visit=$< -f org-html-export-to-html
 
 doc: README.html
 


### PR DESCRIPTION
It let emacs decide if it prefer the .elc or or.el file, this is
needed if only the .elc is available, as it can be on some standard
installation on some distribution.