### PR TITLE
don't query the user about the connection when exiting emacs.

### DIFF
--- a/weechat-relay.el
+++ b/weechat-relay.el
@@ -529,7 +529,8 @@ CALLBACK takes one argument (the response data) which is a list."
                         :host host
                         :service service
                         :coding 'binary
-                        :keepalive t))
+                        :keepalive t
+                        :noquery t))
 
 (defun weechat--relay-open-gnutls-stream (name buffer host service)
   "Just like `open-gnutls-stream' with added validation."


### PR DESCRIPTION
This is a simple change to avoid Emacs' warning "Active processes exist; kill them and exit anyway? (yes or no)" when weechat-relay is connected to weechat and Emacs is about to exit. In my opinion, since disconnecting from the relay doesn't have any side effects (i.e. it doesn't close weechat) there isn't really much point to having this warning and it just gets in the way. However, if you think there is a use-case for keeping this warning, I'd also be willing to update this PR to make it a `custom` option instead of disabling it completely.