### PR TITLE
change reference from rx-form to rx--translate-form

### DIFF
--- a/weechat-color.el
+++ b/weechat-color.el
@@ -79,7 +79,7 @@ This will look very bland!"
          (astd `(seq ,attr (= 2 digit)))
          (ext  `(seq "@" (= 5 digit)))
          (aext `(seq "@" ,attr (= 5 digit))))
-    (rx-form
+    (rx--translate-form
      `(or (seq ""
                (or ,std
                    ,ext


### PR DESCRIPTION
- rx-form no longer exists in 27+ rewrite of rx.el; new function
  rx--translate-form
- addresses https://github.com/the-kenny/weechat.el/issues/80